### PR TITLE
fix(backend): Some refactoring

### DIFF
--- a/backend/src/about/about.controller.ts
+++ b/backend/src/about/about.controller.ts
@@ -1,7 +1,6 @@
 import { Controller, Get, Ip } from "@nestjs/common";
 import { AboutJson } from "./interfaces/about.interface";
-import discord from "../area/services/discord";
-import youtube from "../area/services/youtube";
+import * as services from "../area/services/index";
 import { ApiExtraModels, ApiOkResponse, getSchemaPath } from "@nestjs/swagger";
 
 @Controller()
@@ -16,6 +15,7 @@ export class AboutController {
         }
     })
     about(@Ip() host: string): AboutJson {
+        const _services = Object.values(services).map(({ default: d }) => d);
         const now = new Date().getTime();
         return {
             client: {
@@ -23,7 +23,7 @@ export class AboutController {
             },
             server: {
                 current_time: now,
-                services: [discord, youtube]
+                services: _services
             }
         };
     }

--- a/backend/src/about/interfaces/about.interface.ts
+++ b/backend/src/about/interfaces/about.interface.ts
@@ -1,8 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import {
-    ActionField,
-    ReactionField
-} from "../../area/services/interfaces/service.interface";
+import { AreaServiceAuth } from "../../area/services/interfaces/service.interface";
 
 class AboutJsonClient {
     @ApiProperty({ description: "The host (IP address) of the client." })
@@ -20,12 +17,12 @@ class AboutJsonServerServiceAction {
     })
     readonly description: string;
 
-    @ApiProperty({
-        description: "The fields required to watch the action.",
-        type: ActionField,
-        isArray: true
+    @ApiPropertyOptional({
+        description: "The name of the field.",
+        type: String,
+        examples: ["apiKey", "oauth", "webhook"]
     })
-    readonly fields: ActionField[];
+    readonly auth?: keyof AreaServiceAuth;
 
     @ApiPropertyOptional({
         description:
@@ -48,12 +45,12 @@ class AboutJsonServerServiceReaction {
     })
     readonly description: string;
 
-    @ApiProperty({
-        description: "The fields required to execute the reaction.",
-        type: ReactionField,
-        isArray: true
+    @ApiPropertyOptional({
+        description: "The name of the field.",
+        type: String,
+        examples: ["apiKey", "oauth", "webhook"]
     })
-    readonly fields: ReactionField[];
+    readonly auth?: keyof AreaServiceAuth;
 
     @ApiPropertyOptional({
         description:

--- a/backend/src/area/area.module.ts
+++ b/backend/src/area/area.module.ts
@@ -2,11 +2,10 @@ import { forwardRef, Module } from "@nestjs/common";
 import { AreaController } from "./area.controller";
 import { AreaService } from "./area.service";
 import { PrismaModule } from "../prisma/prisma.module";
-import { OAuthModule } from "../oauth/oauth.module";
 import { SchedulerModule } from "../scheduler/scheduler.module";
 
 @Module({
-    imports: [PrismaModule, OAuthModule, forwardRef(() => SchedulerModule)],
+    imports: [PrismaModule, forwardRef(() => SchedulerModule)],
     controllers: [AreaController],
     providers: [AreaService],
     exports: [AreaService]

--- a/backend/src/area/area.service.spec.ts
+++ b/backend/src/area/area.service.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { AreaService } from "./area.service";
 import { SchedulerService } from "src/scheduler/scheduler.service";
-import { OAuthService } from "src/oauth/oauth.service";
 import { PrismaService } from "src/prisma/prisma.service";
 
 describe("AreaService", () => {
@@ -12,8 +11,7 @@ describe("AreaService", () => {
             providers: [
                 AreaService,
                 { provide: PrismaService, useValue: {} },
-                { provide: SchedulerService, useValue: {} },
-                { provide: OAuthService, useValue: {} }
+                { provide: SchedulerService, useValue: {} }
             ]
         }).compile();
 

--- a/backend/src/area/area.service.ts
+++ b/backend/src/area/area.service.ts
@@ -7,7 +7,6 @@ import {
 } from "@nestjs/common";
 import { User } from "../users/interfaces/user.interface";
 import { CreateAreaDto } from "./dto/createArea.dto";
-import { OAuthService } from "../oauth/oauth.service";
 import { SchedulerService } from "../scheduler/scheduler.service";
 import { YOUTUBE_ACTIONS } from "./services/youtube/youtube.actions";
 import { YOUTUBE_REACTIONS } from "./services/youtube/youtube.reactions";

--- a/backend/src/area/area.service.ts
+++ b/backend/src/area/area.service.ts
@@ -39,8 +39,7 @@ export class AreaService {
     constructor(
         private readonly prismaService: PrismaService,
         @Inject(forwardRef(() => SchedulerService))
-        private readonly schedulerService: SchedulerService,
-        private readonly oauthService: OAuthService
+        private readonly schedulerService: SchedulerService
     ) {}
 
     getAction(actionId: string): AreaAction {
@@ -219,25 +218,17 @@ export class AreaService {
         reactionAuth: AreaServiceAuthDto,
         reaction: AreaReaction
     ): boolean {
-        const actionRequirements = action.config.fields
-            .map(({ name }) => name)
-            .sort();
-        const reactionRequirements = reaction.config.fields
-            .map(({ name }) => name)
-            .sort();
-        const fieldsFilter = (key: string, o: AreaServiceAuthDto) =>
-            "id" !== (key as string) && null !== o[key] && undefined !== o[key];
-        const actionField = Object.keys(actionAuth).filter((key) =>
-            fieldsFilter(key, actionAuth)
+        const actionField = Object.keys(actionAuth).filter(
+            (key) => key === action.config.auth
         )[0] as keyof AreaServiceAuth;
-        const reactionField = Object.keys(reactionAuth).filter((key) =>
-            fieldsFilter(key, reactionAuth)
+
+        const reactionField = Object.keys(reactionAuth).filter(
+            (key) => key === reaction.config.auth
         )[0] as keyof AreaServiceAuth;
+
         return (
-            (0 === actionRequirements.length ||
-                actionRequirements.includes(actionField)) &&
-            (0 === reactionRequirements.length ||
-                reactionRequirements.includes(reactionField))
+            (undefined === action.config.auth || 1 === actionField.length) &&
+            (undefined === reaction.config.auth || 1 === reactionField.length)
         );
     }
 

--- a/backend/src/area/services/discord/discord.reactions.ts
+++ b/backend/src/area/services/discord/discord.reactions.ts
@@ -27,12 +27,7 @@ function sendEmbed(
 export const DISCORD_REACTIONS: { [name: string]: ReactionDescription } = {
     send_embed: {
         description: "Sends an embed message through a Discord webhook.",
-        fields: [
-            {
-                name: "webhook",
-                description: "The Discord webhook to execute."
-            }
-        ],
+        auth: "webhook",
         produce: sendEmbed
     }
 };

--- a/backend/src/area/services/discord/index.ts
+++ b/backend/src/area/services/discord/index.ts
@@ -4,18 +4,18 @@ import { DISCORD_REACTIONS } from "./discord.reactions";
 export default {
     name: "discord",
     actions: Object.entries(DISCORD_ACTIONS).map(
-        ([name, { description, fields, oauthScopes }]) => ({
+        ([name, { description, auth, oauthScopes }]) => ({
             name,
             description,
-            fields,
+            auth,
             oauthScopes
         })
     ),
     reactions: Object.entries(DISCORD_REACTIONS).map(
-        ([name, { description, fields, oauthScopes }]) => ({
+        ([name, { description, auth, oauthScopes }]) => ({
             name,
             description,
-            fields,
+            auth,
             oauthScopes
         })
     )

--- a/backend/src/area/services/interfaces/service.interface.ts
+++ b/backend/src/area/services/interfaces/service.interface.ts
@@ -1,36 +1,5 @@
-import { ApiProperty } from "@nestjs/swagger";
 import { AreaDiscordEmbed } from "../discord/interfaces/discordEmbed.interface";
 import { AreaYouTubeVideo } from "../youtube/interfaces/youtubeVideo.interface";
-
-export class ActionField {
-    @ApiProperty({
-        description: "The name of the field.",
-        type: String,
-        examples: ["apiKey", "oauth", "webhook"]
-    })
-    readonly name: keyof AreaServiceAuth;
-
-    @ApiProperty({
-        description: "The name of the field.",
-        example: "The GitHub webhook URL to get data on action."
-    })
-    readonly description: string;
-}
-
-export class ReactionField {
-    @ApiProperty({
-        description: "The name of the field.",
-        type: String,
-        examples: ["apiKey", "oauth", "webhook"]
-    })
-    readonly name: keyof AreaServiceAuth;
-
-    @ApiProperty({
-        description: "The name of the field.",
-        example: "The Discord webhook URL to execute on reaction."
-    })
-    readonly description: string;
-}
 
 export interface AreaServiceAuth {
     readonly apiKey?: string;
@@ -41,13 +10,13 @@ export interface AreaServiceAuth {
 export interface ActionDescription {
     description: string;
     oauthScopes?: string[];
-    fields: { name: keyof AreaServiceAuth; description: string }[];
+    auth?: keyof AreaServiceAuth;
     trigger: (auth: AreaServiceAuth) => Promise<AreaYouTubeVideo>;
 }
 
 export interface ReactionDescription {
     description: string;
     oauthScopes?: string[];
-    fields: { name: keyof AreaServiceAuth; description: string }[];
+    auth?: keyof AreaServiceAuth;
     produce: (auth: AreaServiceAuth, data: AreaDiscordEmbed) => Promise<void>;
 }

--- a/backend/src/area/services/youtube/index.ts
+++ b/backend/src/area/services/youtube/index.ts
@@ -4,18 +4,18 @@ import { YOUTUBE_REACTIONS } from "./youtube.reactions";
 export default {
     name: "youtube",
     actions: Object.entries(YOUTUBE_ACTIONS).map(
-        ([name, { description, fields, oauthScopes }]) => ({
+        ([name, { description, auth, oauthScopes }]) => ({
             name,
             description,
-            fields,
+            auth,
             oauthScopes
         })
     ),
     reactions: Object.entries(YOUTUBE_REACTIONS).map(
-        ([name, { description, fields, oauthScopes }]) => ({
+        ([name, { description, auth, oauthScopes }]) => ({
             name,
             description,
-            fields,
+            auth,
             oauthScopes
         })
     )

--- a/backend/src/area/services/youtube/youtube.actions.ts
+++ b/backend/src/area/services/youtube/youtube.actions.ts
@@ -44,13 +44,7 @@ export const YOUTUBE_ACTIONS: { [name: string]: ActionDescription } = {
     on_liked_video: {
         description: "This event is triggered once a video has been liked.",
         oauthScopes: ["https://www.googleapis.com/auth/youtube.readonly"],
-        fields: [
-            {
-                name: "oauth",
-                description:
-                    "The OAuth credential ID used to get data from the YouTube API"
-            }
-        ],
+        auth: "oauth",
         trigger: onLikedVideo
     }
 };

--- a/backend/src/oauth/google/google.controller.ts
+++ b/backend/src/oauth/google/google.controller.ts
@@ -1,106 +1,47 @@
-import { getRandomValues } from "node:crypto";
 import { Request, Response } from "express";
 import { SessionData } from "express-session";
-import {
-    Controller,
-    ForbiddenException,
-    Get,
-    HttpCode,
-    HttpStatus,
-    Query,
-    Req,
-    Res,
-    Session,
-    UseGuards
-} from "@nestjs/common";
-import {
-    ApiBearerAuth,
-    ApiExtraModels,
-    ApiForbiddenResponse,
-    ApiOkResponse,
-    ApiQuery,
-    ApiTags,
-    ApiUnauthorizedResponse,
-    getSchemaPath
-} from "@nestjs/swagger";
+import { Controller, Query, Req, Res, Session } from "@nestjs/common";
+import { ApiTags } from "@nestjs/swagger";
 import { GoogleOAuthService } from "./google.service";
-import { JwtGuard } from "../../auth/guards/jwt.guard";
 import { User } from "../../users/interfaces/user.interface";
-import { OAuthCredential } from "../oauth.interface";
+import {
+    OAuthController,
+    OAuthController_callback,
+    OAuthController_credentials,
+    OAuthController_oauthService,
+    OAuthCredential
+} from "../oauth.interface";
 
 @ApiTags("Google OAuth")
 @Controller("oauth/google")
-export class GoogleOAuthController {
+export class GoogleOAuthController implements OAuthController {
     constructor(private readonly googleOAuthService: GoogleOAuthService) {}
 
-    @UseGuards(JwtGuard)
-    @Get("/")
-    @ApiBearerAuth("bearer")
-    @HttpCode(HttpStatus.OK)
-    @ApiOkResponse({
-        description:
-            "Returns the OAuth2.0 URL to which the user will have to log in to the service."
-    })
-    @ApiUnauthorizedResponse({
-        description:
-            "This route is protected. The client must supply a Bearer token."
-    })
-    @ApiQuery({
-        name: "redirect_uri",
-        description:
-            "The URI to which the user will be redirected once the authentication flow is successful.",
-        example: "http://localhost:5173/dashboard"
-    })
-    @ApiQuery({
-        name: "scope",
-        description:
-            "The scopes required for the OAuth2.0 credential. It's a whitespace-joined string list.",
-        example:
-            "https://www.googleapis.com/auth/youtube.readonly https://www.googleapis.com/auth/youtubepartner https://www.googleapis.com/auth/youtube.force-ssl"
-    })
-    oauthService(
-        @Query("redirect_uri") redirect_uri: string,
-        @Query("scope") scope: string,
-        @Req() req: Request
+    @OAuthController_oauthService()
+    getOAuthUrl(
+        @Req() req: Request,
+        @Query("redirect_uri") redirectUri: string,
+        @Query("scope") scope: string
     ) {
         const { id } = req.user as Pick<User, "id">;
-
-        const stateArrayView = new Uint32Array(16);
-        getRandomValues(stateArrayView);
-        const state = Buffer.from(stateArrayView.buffer).toString("hex");
-
-        req.session["state"] = state;
-        req.session["user_id"] = id;
-        req.session["redirect_uri"] = redirect_uri;
-        req.session.save((err) => {
-            if (err) console.error(err);
-        });
-
+        const state = OAuthController.prepareOAuthSession(
+            req.session,
+            id,
+            redirectUri
+        );
         return {
             redirect_uri: this.googleOAuthService.getOAuthUrl(state, scope)
         };
     }
 
-    @Get("/callback")
-    @HttpCode(HttpStatus.OK)
-    @ApiOkResponse({
-        description:
-            "The auth flow has been completed successfully. The Google OAuth2.0 credentials are stored in database and the client is redirected to the root page."
-    })
-    @ApiForbiddenResponse({
-        description:
-            "The 'state' attribute stored in the user' session is either invalid or does not match the one sent by Google. This may happen during a CSRF attack."
-    })
+    @OAuthController_callback()
     async callback(
         @Session() session: SessionData,
         @Query("code") code: string,
         @Query("state") state: string,
         @Res() res: Response
     ) {
-        if (state !== session["state"])
-            throw new ForbiddenException(
-                "Invalid state. Possibly due to a CSRF attack attempt."
-            );
+        OAuthController.verifyState(session, state);
 
         const tokens = await this.googleOAuthService.getCredentials(code);
 
@@ -112,21 +53,7 @@ export class GoogleOAuthController {
         return res.redirect(session["redirect_uri"] || "/");
     }
 
-    @UseGuards(JwtGuard)
-    @Get("/credentials")
-    @ApiExtraModels(OAuthCredential)
-    @ApiBearerAuth("bearer")
-    @ApiOkResponse({
-        description:
-            "Returns all the OAuth2.0 credentials related to the user.",
-        schema: {
-            $ref: getSchemaPath(OAuthCredential)
-        }
-    })
-    @ApiUnauthorizedResponse({
-        description:
-            "This route is protected. The client must supply a Bearer token."
-    })
+    @OAuthController_credentials()
     async credentials(@Req() req: Request): Promise<OAuthCredential[]> {
         const { id } = req.user as Pick<User, "id">;
         return await this.googleOAuthService.loadCredentialsByUserId(id);

--- a/backend/src/oauth/google/google.controller.ts
+++ b/backend/src/oauth/google/google.controller.ts
@@ -8,7 +8,7 @@ import {
     OAuthController,
     OAuthController_callback,
     OAuthController_credentials,
-    OAuthController_oauthService,
+    OAuthController_getOAuthUrl,
     OAuthCredential
 } from "../oauth.interface";
 
@@ -17,7 +17,7 @@ import {
 export class GoogleOAuthController implements OAuthController {
     constructor(private readonly googleOAuthService: GoogleOAuthService) {}
 
-    @OAuthController_oauthService()
+    @OAuthController_getOAuthUrl()
     getOAuthUrl(
         @Req() req: Request,
         @Query("redirect_uri") redirectUri: string,

--- a/backend/src/oauth/google/google.module.ts
+++ b/backend/src/oauth/google/google.module.ts
@@ -1,11 +1,10 @@
 import { Module } from "@nestjs/common";
 import { GoogleOAuthService } from "./google.service";
-import { ConfigModule } from "@nestjs/config";
 import { PrismaModule } from "../../prisma/prisma.module";
 import { GoogleOAuthController } from "./google.controller";
 
 @Module({
-    imports: [ConfigModule, PrismaModule],
+    imports: [PrismaModule],
     providers: [GoogleOAuthService],
     exports: [GoogleOAuthService],
     controllers: [GoogleOAuthController]

--- a/backend/src/oauth/google/google.service.ts
+++ b/backend/src/oauth/google/google.service.ts
@@ -1,13 +1,13 @@
 import * as axios from "axios";
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { OAuth, OAuthCredential } from "../../oauth/oauth.interface";
+import { OAuthManager, OAuthCredential } from "../../oauth/oauth.interface";
 import { OAuthCredential as PrismaOAuthCredential } from "@prisma/client";
 import { User } from "../../users/interfaces/user.interface";
 import { PrismaService } from "../../prisma/prisma.service";
 
 @Injectable()
-export class GoogleOAuthService implements OAuth {
+export class GoogleOAuthService implements OAuthManager {
     private readonly OAUTH_TOKEN_URL: string = `https://oauth2.googleapis.com/token`;
 
     private readonly OAUTH_REVOKE_URL: string = `https://oauth2.googleapis.com/revoke`;

--- a/backend/src/oauth/oauth.interface.ts
+++ b/backend/src/oauth/oauth.interface.ts
@@ -79,7 +79,8 @@ export abstract class OAuthManager {
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
 }
 
-export function OAuthController_getOAuthUrl(): MethodDecorator & ClassDecorator {
+export function OAuthController_getOAuthUrl(): MethodDecorator &
+    ClassDecorator {
     return applyDecorators(
         UseGuards(JwtGuard),
         Get("/"),
@@ -124,7 +125,8 @@ export function OAuthController_callback(): MethodDecorator & ClassDecorator {
     );
 }
 
-export function OAuthController_credentials(): MethodDecorator & ClassDecorator {
+export function OAuthController_credentials(): MethodDecorator &
+    ClassDecorator {
     return applyDecorators(
         UseGuards(JwtGuard),
         Get("/credentials"),

--- a/backend/src/oauth/oauth.interface.ts
+++ b/backend/src/oauth/oauth.interface.ts
@@ -79,8 +79,7 @@ export abstract class OAuthManager {
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
 }
 
-// @typescript-eslint/no-unsafe-function-type
-export function OAuthController_getOAuthUrl() {
+export function OAuthController_getOAuthUrl(): MethodDecorator & ClassDecorator {
     return applyDecorators(
         UseGuards(JwtGuard),
         Get("/"),
@@ -110,8 +109,7 @@ export function OAuthController_getOAuthUrl() {
     );
 }
 
-// @typescript-eslint/no-unsafe-function-type
-export function OAuthController_callback() {
+export function OAuthController_callback(): MethodDecorator & ClassDecorator {
     return applyDecorators(
         Get("/callback"),
         HttpCode(HttpStatus.OK),
@@ -126,8 +124,7 @@ export function OAuthController_callback() {
     );
 }
 
-// @typescript-eslint/no-unsafe-function-type
-export function OAuthController_credentials() {
+export function OAuthController_credentials(): MethodDecorator & ClassDecorator {
     return applyDecorators(
         UseGuards(JwtGuard),
         Get("/credentials"),

--- a/backend/src/oauth/oauth.interface.ts
+++ b/backend/src/oauth/oauth.interface.ts
@@ -1,5 +1,26 @@
-import { ApiProperty } from "@nestjs/swagger";
+import {
+    ApiBearerAuth,
+    ApiExtraModels,
+    ApiForbiddenResponse,
+    ApiOkResponse,
+    ApiProperty,
+    ApiQuery,
+    ApiUnauthorizedResponse,
+    getSchemaPath
+} from "@nestjs/swagger";
 import { User } from "../users/interfaces/user.interface";
+import { JwtGuard } from "src/auth/guards/jwt.guard";
+import {
+    applyDecorators,
+    ForbiddenException,
+    Get,
+    HttpCode,
+    HttpStatus,
+    UseGuards
+} from "@nestjs/common";
+import { SessionData } from "express-session";
+import { Request, Response } from "express";
+import { getRandomValues } from "crypto";
 
 export class OAuthCredential {
     @ApiProperty({ description: "The ID of the Google OAuth authorization." })
@@ -27,7 +48,7 @@ export class OAuthCredential {
     readonly scope: string;
 }
 
-export abstract class OAuth {
+export abstract class OAuthManager {
     abstract getOAuthUrl(state: string, scope: string): string;
 
     abstract getCredentials(code: string): Promise<OAuthCredential>;
@@ -56,4 +77,112 @@ export abstract class OAuth {
     abstract updateCredential(oauthCredential: OAuthCredential): Promise<void>;
 
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
+}
+
+export function OAuthController_oauthService() {
+    return applyDecorators(
+        UseGuards(JwtGuard),
+        Get("/"),
+        HttpCode(HttpStatus.OK),
+        ApiBearerAuth("bearer"),
+        ApiOkResponse({
+            description:
+                "Returns the OAuth2.0 URL to which the user will have to log in to the service."
+        }),
+        ApiUnauthorizedResponse({
+            description:
+                "This route is protected. The client must supply a Bearer token."
+        }),
+        ApiQuery({
+            name: "redirect_uri",
+            description:
+                "The URI to which the user will be redirected once the authentication flow is successful.",
+            example: "http://localhost:5173/dashboard"
+        }),
+        ApiQuery({
+            name: "scope",
+            description:
+                "The scopes required for the OAuth2.0 credential. It's a whitespace-joined string list.",
+            example:
+                "https://www.googleapis.com/auth/youtube.readonly https://www.googleapis.com/auth/youtubepartner https://www.googleapis.com/auth/youtube.force-ssl"
+        })
+    );
+}
+
+export function OAuthController_callback() {
+    return applyDecorators(
+        Get("/callback"),
+        HttpCode(HttpStatus.OK),
+        ApiOkResponse({
+            description:
+                "The auth flow has been completed successfully. The Google OAuth2.0 credentials are stored in database and the client is redirected to the root page."
+        }),
+        ApiForbiddenResponse({
+            description:
+                "The 'state' attribute stored in the user' session is either invalid or does not match the one sent by Google. This may happen during a CSRF attack."
+        })
+    );
+}
+
+export function OAuthController_credentials() {
+    return applyDecorators(
+        UseGuards(JwtGuard),
+        Get("/credentials"),
+        ApiExtraModels(OAuthCredential),
+        ApiBearerAuth("bearer"),
+        ApiOkResponse({
+            description:
+                "Returns all the OAuth2.0 credentials related to the user.",
+            schema: {
+                $ref: getSchemaPath(OAuthCredential)
+            }
+        }),
+        ApiUnauthorizedResponse({
+            description:
+                "This route is protected. The client must supply a Bearer token."
+        })
+    );
+}
+
+export abstract class OAuthController {
+    static prepareOAuthSession(
+        session: Request["session"],
+        userId: User["id"],
+        redirectUri: string
+    ): string {
+        const stateArrayView = new Uint32Array(16);
+        getRandomValues(stateArrayView);
+        const state = Buffer.from(stateArrayView.buffer).toString("hex");
+
+        session["state"] = state;
+        session["user_id"] = userId;
+        session["redirect_uri"] = redirectUri;
+        session.save((err) => {
+            if (err) console.error(err);
+        });
+
+        return state;
+    }
+
+    static verifyState(session: SessionData, state: string): void {
+        if (state !== session["state"])
+            throw new ForbiddenException(
+                "Invalid state. Possibly due to a CSRF attack attempt."
+            );
+    }
+
+    abstract getOAuthUrl(
+        req: Request,
+        redirectUri: string,
+        scope: string
+    ): { redirect_uri: string };
+
+    abstract callback(
+        session: SessionData,
+        code: string,
+        state: string,
+        res: Response
+    ): Promise<void>;
+
+    abstract credentials(req: Request): Promise<OAuthCredential[]>;
 }

--- a/backend/src/oauth/oauth.interface.ts
+++ b/backend/src/oauth/oauth.interface.ts
@@ -79,7 +79,8 @@ export abstract class OAuthManager {
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
 }
 
-export function OAuthController_oauthService() {
+// @typescript-eslint/no-unsafe-function-type
+export function OAuthController_getOAuthUrl() {
     return applyDecorators(
         UseGuards(JwtGuard),
         Get("/"),
@@ -109,6 +110,7 @@ export function OAuthController_oauthService() {
     );
 }
 
+// @typescript-eslint/no-unsafe-function-type
 export function OAuthController_callback() {
     return applyDecorators(
         Get("/callback"),
@@ -124,6 +126,7 @@ export function OAuthController_callback() {
     );
 }
 
+// @typescript-eslint/no-unsafe-function-type
 export function OAuthController_credentials() {
     return applyDecorators(
         UseGuards(JwtGuard),

--- a/backend/src/oauth/oauth.service.ts
+++ b/backend/src/oauth/oauth.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from "@nestjs/common";
 import { GoogleOAuthService } from "./google/google.service";
-import { OAuth } from "./oauth.interface";
+import { OAuthManager } from "./oauth.interface";
 
 @Injectable()
 export class OAuthService {
     constructor(private readonly googleOAuthService: GoogleOAuthService) {}
 
-    getOAuthCredentialsManager(name: string): OAuth {
+    getOAuthCredentialsManager(name: string): OAuthManager {
         return { youtube: this.googleOAuthService }[name];
     }
 }

--- a/backend/src/scheduler/scheduler.service.ts
+++ b/backend/src/scheduler/scheduler.service.ts
@@ -10,7 +10,7 @@ import {
 import { Cache } from "cache-manager";
 import { hash } from "crypto";
 import { transformer } from "../area/generic_transformer";
-import { OAuth, OAuthCredential } from "../oauth/oauth.interface";
+import { OAuthManager, OAuthCredential } from "../oauth/oauth.interface";
 import { AreaStatus } from "@prisma/client";
 import { AreaTask } from "../area/interfaces/area.interface";
 import { AreaService } from "../area/area.service";
@@ -40,7 +40,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
 
     private async getOAuthCredential(
         scopes: string[],
-        credentialsManager: OAuth
+        credentialsManager: OAuthManager
     ): Promise<OAuthCredential | null> {
         const credentials: OAuthCredential[] =
             await credentialsManager.loadCredentialsByScopes(scopes);

--- a/common/src/types/about/interfaces/about.interface.d.ts
+++ b/common/src/types/about/interfaces/about.interface.d.ts
@@ -1,17 +1,17 @@
-import { ActionField, ReactionField } from "../../area/services/interfaces/service.interface";
+import { AreaServiceAuth } from "../../area/services/interfaces/service.interface";
 declare class AboutJsonClient {
     readonly host: string;
 }
 declare class AboutJsonServerServiceAction {
     readonly name: string;
     readonly description: string;
-    readonly fields: ActionField[];
+    readonly auth?: keyof AreaServiceAuth;
     readonly oauthScopes?: string[];
 }
 declare class AboutJsonServerServiceReaction {
     readonly name: string;
     readonly description: string;
-    readonly fields: ReactionField[];
+    readonly auth?: keyof AreaServiceAuth;
     readonly oauthScopes?: string[];
 }
 declare class AboutJsonServerService {

--- a/common/src/types/area/services/interfaces/service.interface.d.ts
+++ b/common/src/types/area/services/interfaces/service.interface.d.ts
@@ -1,13 +1,5 @@
 import { AreaDiscordEmbed } from "../discord/interfaces/discordEmbed.interface";
 import { AreaYouTubeVideo } from "../youtube/interfaces/youtubeVideo.interface";
-export declare class ActionField {
-    readonly name: keyof AreaServiceAuth;
-    readonly description: string;
-}
-export declare class ReactionField {
-    readonly name: keyof AreaServiceAuth;
-    readonly description: string;
-}
 export interface AreaServiceAuth {
     readonly apiKey?: string;
     readonly oauth?: string;
@@ -16,18 +8,12 @@ export interface AreaServiceAuth {
 export interface ActionDescription {
     description: string;
     oauthScopes?: string[];
-    fields: {
-        name: keyof AreaServiceAuth;
-        description: string;
-    }[];
+    auth?: keyof AreaServiceAuth;
     trigger: (auth: AreaServiceAuth) => Promise<AreaYouTubeVideo>;
 }
 export interface ReactionDescription {
     description: string;
     oauthScopes?: string[];
-    fields: {
-        name: keyof AreaServiceAuth;
-        description: string;
-    }[];
+    auth?: keyof AreaServiceAuth;
     produce: (auth: AreaServiceAuth, data: AreaDiscordEmbed) => Promise<void>;
 }

--- a/common/src/types/oauth/oauth.interface.d.ts
+++ b/common/src/types/oauth/oauth.interface.d.ts
@@ -19,11 +19,13 @@ export declare abstract class OAuthManager {
     abstract updateCredential(oauthCredential: OAuthCredential): Promise<void>;
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
 }
-export declare function OAuthController_oauthService(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
+export declare function OAuthController_getOAuthUrl(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
 export declare function OAuthController_callback(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
 export declare function OAuthController_credentials(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
 export declare abstract class OAuthController {
-    abstract getOAuthUrl(redirect_uri: string, scope: string, req: Request): {
+    static prepareOAuthSession(session: Request["session"], userId: User["id"], redirectUri: string): string;
+    static verifyState(session: SessionData, state: string): void;
+    abstract getOAuthUrl(req: Request, redirectUri: string, scope: string): {
         redirect_uri: string;
     };
     abstract callback(session: SessionData, code: string, state: string, res: Response): Promise<void>;

--- a/common/src/types/oauth/oauth.interface.d.ts
+++ b/common/src/types/oauth/oauth.interface.d.ts
@@ -1,4 +1,6 @@
 import { User } from "../users/interfaces/user.interface";
+import { SessionData } from "express-session";
+import { Request, Response } from "express";
 export declare class OAuthCredential {
     readonly id?: number;
     readonly access_token: string;
@@ -6,7 +8,7 @@ export declare class OAuthCredential {
     readonly expires_at: Date;
     readonly scope: string;
 }
-export declare abstract class OAuth {
+export declare abstract class OAuthManager {
     abstract getOAuthUrl(state: string, scope: string): string;
     abstract getCredentials(code: string): Promise<OAuthCredential>;
     abstract saveCredential(userId: User["id"], credential: OAuthCredential): Promise<number>;
@@ -16,4 +18,14 @@ export declare abstract class OAuth {
     abstract refreshCredential(oauthCredential: OAuthCredential): Promise<OAuthCredential>;
     abstract updateCredential(oauthCredential: OAuthCredential): Promise<void>;
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
+}
+export declare function OAuthController_oauthService(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
+export declare function OAuthController_callback(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
+export declare function OAuthController_credentials(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
+export declare abstract class OAuthController {
+    abstract getOAuthUrl(redirect_uri: string, scope: string, req: Request): {
+        redirect_uri: string;
+    };
+    abstract callback(session: SessionData, code: string, state: string, res: Response): Promise<void>;
+    abstract credentials(req: Request): Promise<OAuthCredential[]>;
 }

--- a/common/src/types/oauth/oauth.interface.d.ts
+++ b/common/src/types/oauth/oauth.interface.d.ts
@@ -19,9 +19,9 @@ export declare abstract class OAuthManager {
     abstract updateCredential(oauthCredential: OAuthCredential): Promise<void>;
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
 }
-export declare function OAuthController_getOAuthUrl(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
-export declare function OAuthController_callback(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
-export declare function OAuthController_credentials(): <TFunction extends Function, Y>(target: TFunction | object, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<Y>) => void;
+export declare function OAuthController_getOAuthUrl(): MethodDecorator & ClassDecorator;
+export declare function OAuthController_callback(): MethodDecorator & ClassDecorator;
+export declare function OAuthController_credentials(): MethodDecorator & ClassDecorator;
 export declare abstract class OAuthController {
     static prepareOAuthSession(session: Request["session"], userId: User["id"], redirectUri: string): string;
     static verifyState(session: SessionData, state: string): void;


### PR DESCRIPTION
A few things got refactored. Firstly, the GoogleOAuthController, and all the newer OAuthController, will have to `implements` the `OAuthController` abstract class, as it's meant to provide a skeleton to make it usable, and auto-referencing the routes on the swagger. Also, the `about.json` got refactored to automatically import new action and reaction service providers in the JSON document.