### PR TITLE
feat(backend): adding the Discord OAuth implementation

### DIFF
--- a/backend/src/about/about.controller.ts
+++ b/backend/src/about/about.controller.ts
@@ -16,13 +16,13 @@ export class AboutController {
     })
     about(@Ip() host: string): AboutJson {
         const _services = Object.values(services).map(({ default: d }) => d);
-        const now = new Date().getTime();
+
         return {
             client: {
                 host
             },
             server: {
-                current_time: now,
+                current_time: Date.now(),
                 services: _services
             }
         };

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { AboutModule } from "./about/about.module";
 import { PrismaService } from "./prisma/prisma.service";
 import { AreaService } from "./area/area.service";
 import { WebhookModule } from "./webhook/webhook.module";
+import { OAuthDBService } from "./oauth/oauthDb.service";
 
 @Module({
     imports: [
@@ -36,7 +37,8 @@ import { WebhookModule } from "./webhook/webhook.module";
         AboutModule,
         WebhookModule
     ],
-    providers: [JwtGuard]
+    providers: [JwtGuard, OAuthDBService],
+    controllers: []
 })
 export class AppModule implements OnModuleInit {
     constructor(

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -29,7 +29,15 @@ function getSwaggerDocumentConfig(): Omit<OpenAPIObject, "paths"> {
             "Google OAuth",
             "Describes all the endpoints to deal with Google OAuth2.0 credentials."
         )
+        .addTag(
+            "Discord OAuth",
+            "Describes all the endpoints to deal with Discord OAuth2.0 credentials."
+        )
         .addTag("AREA", "Describes all the routes to deal with AREA's CRUD.")
+        .addTag(
+            "Webhooks",
+            "Describes all the endpoints to deal with the AREA webhooks."
+        )
         .addTag("Users", "Describes all the routes to deal with users CRUD.")
         .addBearerAuth({
             type: "http",

--- a/backend/src/oauth/discord/discord.controller.spec.ts
+++ b/backend/src/oauth/discord/discord.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DiscordOAuthController } from './discord.controller';
+
+describe('DiscordController', () => {
+  let controller: DiscordOAuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DiscordOAuthController],
+    }).compile();
+
+    controller = module.get<DiscordOAuthController>(DiscordOAuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/oauth/discord/discord.controller.spec.ts
+++ b/backend/src/oauth/discord/discord.controller.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { DiscordOAuthController } from './discord.controller';
+import { Test, TestingModule } from "@nestjs/testing";
+import { DiscordOAuthController } from "./discord.controller";
 
-describe('DiscordController', () => {
-  let controller: DiscordOAuthController;
+describe("DiscordController", () => {
+    let controller: DiscordOAuthController;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      controllers: [DiscordOAuthController],
-    }).compile();
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [DiscordOAuthController]
+        }).compile();
 
-    controller = module.get<DiscordOAuthController>(DiscordOAuthController);
-  });
+        controller = module.get<DiscordOAuthController>(DiscordOAuthController);
+    });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
+    it("should be defined", () => {
+        expect(controller).toBeDefined();
+    });
 });

--- a/backend/src/oauth/discord/discord.controller.ts
+++ b/backend/src/oauth/discord/discord.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { SessionData } from "express-session";
 import { Controller, Query, Req, Res, Session } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
-import { GoogleOAuthService } from "./google.service";
+import { DiscordOAuthService } from "./discord.service";
 import { User } from "../../users/interfaces/user.interface";
 import {
     OAuthController,
@@ -12,10 +12,10 @@ import {
     OAuthCredential
 } from "../oauth.interface";
 
-@ApiTags("Google OAuth")
-@Controller("oauth/google")
-export class GoogleOAuthController implements OAuthController {
-    constructor(private readonly googleOAuthService: GoogleOAuthService) {}
+@ApiTags("Discord OAuth")
+@Controller("oauth/discord")
+export class DiscordOAuthController implements OAuthController {
+    constructor(private readonly discordOAuthService: DiscordOAuthService) {}
 
     @OAuthController_getOAuthUrl()
     getOAuthUrl(
@@ -30,7 +30,7 @@ export class GoogleOAuthController implements OAuthController {
             redirectUri
         );
         return {
-            redirect_uri: this.googleOAuthService.getOAuthUrl(state, scope)
+            redirect_uri: this.discordOAuthService.getOAuthUrl(state, scope)
         };
     }
 
@@ -43,13 +43,13 @@ export class GoogleOAuthController implements OAuthController {
     ) {
         OAuthController.verifyState(session, state);
 
-        const tokens = await this.googleOAuthService.getCredentials(code);
+        const tokens = await this.discordOAuthService.getCredentials(code);
 
-        await this.googleOAuthService.saveCredential(
+        await this.discordOAuthService.saveCredential(
             session["user_id"],
             tokens,
-            this.googleOAuthService.OAUTH_TOKEN_URL,
-            this.googleOAuthService.OAUTH_REVOKE_URL
+            this.discordOAuthService.OAUTH_TOKEN_URL,
+            this.discordOAuthService.OAUTH_REVOKE_URL
         );
 
         return res.redirect(session["redirect_uri"] || "/");
@@ -58,10 +58,10 @@ export class GoogleOAuthController implements OAuthController {
     @OAuthController_credentials()
     async credentials(@Req() req: Request): Promise<OAuthCredential[]> {
         const { id } = req.user as Pick<User, "id">;
-        return await this.googleOAuthService.loadCredentialsByUserId(
+        return await this.discordOAuthService.loadCredentialsByUserId(
             id,
-            this.googleOAuthService.OAUTH_TOKEN_URL,
-            this.googleOAuthService.OAUTH_REVOKE_URL
+            this.discordOAuthService.OAUTH_TOKEN_URL,
+            this.discordOAuthService.OAUTH_REVOKE_URL
         );
     }
 }

--- a/backend/src/oauth/discord/discord.module.ts
+++ b/backend/src/oauth/discord/discord.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { DiscordOAuthService } from "./discord.service";
+import { DiscordOAuthController } from "./discord.controller";
+import { PrismaModule } from "src/prisma/prisma.module";
+
+@Module({
+    imports: [PrismaModule],
+    providers: [DiscordOAuthService],
+    exports: [DiscordOAuthService],
+    controllers: [DiscordOAuthController]
+})
+export class DiscordOAuthModule {}

--- a/backend/src/oauth/discord/discord.service.spec.ts
+++ b/backend/src/oauth/discord/discord.service.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { DiscordOAuthService } from "./discord.service";
+import { PrismaClient } from "@prisma/client";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+import { PrismaService } from "src/prisma/prisma.service";
+import { ConfigService } from "@nestjs/config";
+
+describe("DiscordService", () => {
+    let service: DiscordOAuthService;
+
+    let prismaService: DeepMockProxy<PrismaClient>;
+    beforeEach(async () => {
+        prismaService = mockDeep<PrismaClient>();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                DiscordOAuthService,
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn()
+                    }
+                },
+                { provide: PrismaService, useValue: prismaService }
+            ]
+        }).compile();
+
+        service = module.get<DiscordOAuthService>(DiscordOAuthService);
+    });
+
+    it("should be defined", () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/backend/src/oauth/discord/discord.service.ts
+++ b/backend/src/oauth/discord/discord.service.ts
@@ -87,9 +87,7 @@ export class DiscordOAuthService
             access_token: response.access_token,
             refresh_token: response.refresh_token,
             scope: response.scope,
-            expires_at: new Date(
-                new Date().getTime() + response.expires_in * 1000
-            )
+            expires_at: new Date(Date.now() + response.expires_in * 1000)
         };
     }
 
@@ -123,9 +121,7 @@ export class DiscordOAuthService
             access_token: response.access_token,
             refresh_token: oauthCredential.refresh_token,
             scope: response.scope,
-            expires_at: new Date(
-                new Date().getTime() + response.expires_in * 1000
-            )
+            expires_at: new Date(Date.now() + response.expires_in * 1000)
         };
     }
 

--- a/backend/src/oauth/google/google.service.ts
+++ b/backend/src/oauth/google/google.service.ts
@@ -84,9 +84,7 @@ export class GoogleOAuthService extends OAuthDBService implements OAuthManager {
             access_token: response.access_token,
             refresh_token: response.refresh_token,
             scope: response.scope,
-            expires_at: new Date(
-                new Date().getTime() + response.expires_in * 1000
-            )
+            expires_at: new Date(Date.now() + response.expires_in * 1000)
         };
     }
 
@@ -120,9 +118,7 @@ export class GoogleOAuthService extends OAuthDBService implements OAuthManager {
             access_token: response.access_token,
             refresh_token: oauthCredential.refresh_token,
             scope: response.scope,
-            expires_at: new Date(
-                new Date().getTime() + response.expires_in * 1000
-            )
+            expires_at: new Date(Date.now() + response.expires_in * 1000)
         };
     }
 

--- a/backend/src/oauth/oauth.controller.spec.ts
+++ b/backend/src/oauth/oauth.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OauthController } from './oauth.controller';
+
+describe('OauthController', () => {
+  let controller: OauthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OauthController],
+    }).compile();
+
+    controller = module.get<OauthController>(OauthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/oauth/oauth.controller.spec.ts
+++ b/backend/src/oauth/oauth.controller.spec.ts
@@ -1,18 +1,18 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { OauthController } from './oauth.controller';
+import { Test, TestingModule } from "@nestjs/testing";
+import { OauthController } from "./oauth.controller";
 
-describe('OauthController', () => {
-  let controller: OauthController;
+describe("OauthController", () => {
+    let controller: OauthController;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      controllers: [OauthController],
-    }).compile();
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [OauthController]
+        }).compile();
 
-    controller = module.get<OauthController>(OauthController);
-  });
+        controller = module.get<OauthController>(OauthController);
+    });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
+    it("should be defined", () => {
+        expect(controller).toBeDefined();
+    });
 });

--- a/backend/src/oauth/oauth.interface.ts
+++ b/backend/src/oauth/oauth.interface.ts
@@ -21,6 +21,8 @@ import {
 import { SessionData } from "express-session";
 import { Request, Response } from "express";
 import { getRandomValues } from "crypto";
+import { OAuthDBService } from "./oauthDb.service";
+import { hash } from "crypto";
 
 export class OAuthCredential {
     @ApiProperty({ description: "The ID of the Google OAuth authorization." })
@@ -48,33 +50,18 @@ export class OAuthCredential {
     readonly scope: string;
 }
 
-export abstract class OAuthManager {
+export abstract class OAuthManager extends OAuthDBService {
+    readonly OAUTH_TOKEN_URL: string;
+
+    readonly OAUTH_REVOKE_URL: string;
+
     abstract getOAuthUrl(state: string, scope: string): string;
 
     abstract getCredentials(code: string): Promise<OAuthCredential>;
 
-    abstract saveCredential(
-        userId: User["id"],
-        credential: OAuthCredential
-    ): Promise<number>;
-
-    abstract loadCredentialsByUserId(
-        userId: User["id"]
-    ): Promise<OAuthCredential[]>;
-
-    abstract loadCredentialsByScopes(
-        scopes: string[]
-    ): Promise<OAuthCredential[]>;
-
-    abstract loadCredentialById(
-        oauthCredentialId: OAuthCredential["id"]
-    ): Promise<OAuthCredential>;
-
     abstract refreshCredential(
         oauthCredential: OAuthCredential
     ): Promise<OAuthCredential>;
-
-    abstract updateCredential(oauthCredential: OAuthCredential): Promise<void>;
 
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
 }
@@ -152,12 +139,10 @@ export abstract class OAuthController {
         userId: User["id"],
         redirectUri: string
     ): string {
-        const stateArrayView = new Uint32Array(16);
-        getRandomValues(stateArrayView);
-        const state = Buffer.from(stateArrayView.buffer).toString("hex");
+        session["user_id"] = userId;
+        const state = hash("SHA-512", session["user_id"], "hex");
 
         session["state"] = state;
-        session["user_id"] = userId;
         session["redirect_uri"] = redirectUri;
         session.save((err) => {
             if (err) console.error(err);
@@ -167,7 +152,13 @@ export abstract class OAuthController {
     }
 
     static verifyState(session: SessionData, state: string): void {
-        if (state !== session["state"])
+        if (undefined === session["user_id"])
+            throw new ForbiddenException(
+                "Session expired."
+            );
+
+        const currentState = hash("SHA-512", session["user_id"], "hex");
+        if (state !== currentState)
             throw new ForbiddenException(
                 "Invalid state. Possibly due to a CSRF attack attempt."
             );
@@ -185,6 +176,4 @@ export abstract class OAuthController {
         state: string,
         res: Response
     ): Promise<void>;
-
-    abstract credentials(req: Request): Promise<OAuthCredential[]>;
 }

--- a/backend/src/oauth/oauth.module.ts
+++ b/backend/src/oauth/oauth.module.ts
@@ -2,11 +2,14 @@ import { Module } from "@nestjs/common";
 import { GoogleOAuthModule } from "./google/google.module";
 import { GoogleOAuthController } from "./google/google.controller";
 import { OAuthService } from "./oauth.service";
+import { DiscordOAuthModule } from "./discord/discord.module";
+import { OAuthDBService } from "./oauthDb.service";
+import { PrismaModule } from "src/prisma/prisma.module";
 
 @Module({
-    imports: [GoogleOAuthModule],
+    imports: [PrismaModule, GoogleOAuthModule, DiscordOAuthModule],
     controllers: [GoogleOAuthController],
-    providers: [OAuthService],
+    providers: [OAuthService, OAuthDBService],
     exports: [OAuthService]
 })
 export class OAuthModule {}

--- a/backend/src/oauth/oauth.service.spec.ts
+++ b/backend/src/oauth/oauth.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { OAuthService } from "./oauth.service";
 import { GoogleOAuthService } from "./google/google.service";
+import { DiscordOAuthService } from "./discord/discord.service";
 
 describe("OauthService", () => {
     let service: OAuthService;
@@ -9,7 +10,8 @@ describe("OauthService", () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 OAuthService,
-                { provide: GoogleOAuthService, useValue: {} }
+                { provide: GoogleOAuthService, useValue: {} },
+                { provide: DiscordOAuthService, useValue: {} }
             ]
         }).compile();
 

--- a/backend/src/oauth/oauth.service.ts
+++ b/backend/src/oauth/oauth.service.ts
@@ -1,12 +1,19 @@
 import { Injectable } from "@nestjs/common";
-import { GoogleOAuthService } from "./google/google.service";
 import { OAuthManager } from "./oauth.interface";
+import { GoogleOAuthService } from "./google/google.service";
+import { DiscordOAuthService } from "./discord/discord.service";
 
 @Injectable()
 export class OAuthService {
-    constructor(private readonly googleOAuthService: GoogleOAuthService) {}
+    constructor(
+        private readonly googleOAuthService: GoogleOAuthService,
+        private readonly discordOAuthService: DiscordOAuthService
+    ) {}
 
     getOAuthCredentialsManager(name: string): OAuthManager {
-        return { youtube: this.googleOAuthService }[name];
+        return {
+            youtube: this.googleOAuthService,
+            discord: this.discordOAuthService
+        }[name];
     }
 }

--- a/backend/src/oauth/oauthDb.service.spec.ts
+++ b/backend/src/oauth/oauthDb.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { OAuthDBService } from "./oauthDb.service";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+import { PrismaClient } from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+
+describe("OAuthDBService", () => {
+    let service: OAuthDBService;
+    let prismaService: DeepMockProxy<PrismaClient>;
+
+    beforeEach(async () => {
+        prismaService = mockDeep<PrismaClient>();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                OAuthDBService,
+                { provide: PrismaService, useValue: prismaService }
+            ]
+        }).compile();
+
+        service = module.get<OAuthDBService>(OAuthDBService);
+    });
+
+    it("should be defined", () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/backend/src/oauth/oauthDb.service.ts
+++ b/backend/src/oauth/oauthDb.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { User, OAuthCredential as PrismaOAuthCredential } from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+import { OAuthCredential } from "./oauth.interface";
+
+@Injectable()
+export class OAuthDBService {
+    constructor(protected readonly prismaService: PrismaService) {}
+
+    private prismaCredentialToCredential({
+        id,
+        accessToken,
+        refreshToken,
+        expiresAt,
+        scopes
+    }: Partial<PrismaOAuthCredential>): OAuthCredential {
+        return {
+            id,
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            expires_at: expiresAt,
+            scope: scopes.join(" ")
+        };
+    }
+
+    async saveCredential(
+        userId: User["id"],
+        credential: OAuthCredential,
+        oauthTokenUrl: string,
+        oauthRevokeUrl: string
+    ): Promise<number> {
+        return (
+            await this.prismaService.oAuthCredential.create({
+                data: {
+                    accessToken: credential.access_token,
+                    refreshToken: credential.refresh_token,
+                    expiresAt: credential.expires_at,
+                    scopes: credential.scope.split(" "),
+                    tokenUrl: oauthTokenUrl,
+                    revokeUrl: oauthRevokeUrl,
+                    userId
+                },
+                select: {
+                    id: true
+                }
+            })
+        ).id;
+    }
+
+    async loadCredentialsByUserId(
+        userId: User["id"],
+        oauthTokenUrl: string,
+        oauthRevokeUrl: string
+    ): Promise<OAuthCredential[]> {
+        return (
+            await this.prismaService.oAuthCredential.findMany({
+                where: {
+                    userId,
+                    tokenUrl: oauthTokenUrl,
+                    revokeUrl: oauthRevokeUrl
+                },
+                select: {
+                    id: true,
+                    accessToken: true,
+                    refreshToken: true,
+                    expiresAt: true,
+                    scopes: true
+                }
+            })
+        ).map(this.prismaCredentialToCredential);
+    }
+
+    async loadCredentialsByScopes(
+        scopes: string[],
+        oauthTokenUrl: string,
+        oauthRevokeUrl: string
+    ): Promise<OAuthCredential[]> {
+        return (
+            await this.prismaService.oAuthCredential.findMany({
+                where: {
+                    scopes: { hasEvery: scopes },
+                    tokenUrl: oauthTokenUrl,
+                    revokeUrl: oauthRevokeUrl
+                },
+                select: {
+                    id: true,
+                    accessToken: true,
+                    refreshToken: true,
+                    expiresAt: true,
+                    scopes: true
+                }
+            })
+        ).map(this.prismaCredentialToCredential);
+    }
+
+    async loadCredentialById(
+        oauthCredentialId: OAuthCredential["id"]
+    ): Promise<OAuthCredential> {
+        const credential = await this.prismaService.oAuthCredential.findUnique({
+            where: {
+                id: oauthCredentialId
+            },
+            select: {
+                id: true,
+                accessToken: true,
+                refreshToken: true,
+                expiresAt: true,
+                scopes: true
+            }
+        });
+
+        if (null === credential) throw new NotFoundException();
+        return this.prismaCredentialToCredential(credential);
+    }
+
+    async updateCredential(oauthCredential: OAuthCredential): Promise<void> {
+        await this.prismaService.oAuthCredential.update({
+            where: {
+                id: oauthCredential.id
+            },
+            data: {
+                accessToken: oauthCredential.access_token,
+                refreshToken: oauthCredential.refresh_token,
+                expiresAt: oauthCredential.expires_at,
+                scopes: oauthCredential.scope.split(" ")
+            }
+        });
+    }
+
+    async deleteCredential(oauthCredential: OAuthCredential) {
+        await this.prismaService.oAuthCredential.delete({
+            where: {
+                id: oauthCredential.id
+            }
+        });
+    }
+}

--- a/backend/src/scheduler/scheduler.service.ts
+++ b/backend/src/scheduler/scheduler.service.ts
@@ -43,7 +43,11 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         credentialsManager: OAuthManager
     ): Promise<OAuthCredential | null> {
         const credentials: OAuthCredential[] =
-            await credentialsManager.loadCredentialsByScopes(scopes);
+            await credentialsManager.loadCredentialsByScopes(
+                scopes,
+                credentialsManager.OAUTH_TOKEN_URL,
+                credentialsManager.OAUTH_REVOKE_URL
+            );
         if (0 === credentials.length) return null;
 
         const credential = credentials[0];

--- a/backend/src/webhook/webhook.controller.ts
+++ b/backend/src/webhook/webhook.controller.ts
@@ -3,7 +3,7 @@ import { ApiNotFoundResponse, ApiOkResponse, ApiTags } from "@nestjs/swagger";
 import { WebhookService } from "./webhook.service";
 import { Area } from "src/area/interfaces/area.interface";
 
-@ApiTags("webhook")
+@ApiTags("Webhooks")
 @Controller("webhooks")
 export class WebhookController {
     constructor(private readonly webhookService: WebhookService) {}

--- a/common/src/types/oauth/oauth.interface.d.ts
+++ b/common/src/types/oauth/oauth.interface.d.ts
@@ -10,6 +10,8 @@ export declare class OAuthCredential {
     readonly scope: string;
 }
 export declare abstract class OAuthManager extends OAuthDBService {
+    readonly OAUTH_TOKEN_URL: string;
+    readonly OAUTH_REVOKE_URL: string;
     abstract getOAuthUrl(state: string, scope: string): string;
     abstract getCredentials(code: string): Promise<OAuthCredential>;
     abstract refreshCredential(oauthCredential: OAuthCredential): Promise<OAuthCredential>;
@@ -25,5 +27,4 @@ export declare abstract class OAuthController {
         redirect_uri: string;
     };
     abstract callback(session: SessionData, code: string, state: string, res: Response): Promise<void>;
-    abstract credentials(req: Request): Promise<OAuthCredential[]>;
 }

--- a/common/src/types/oauth/oauth.interface.d.ts
+++ b/common/src/types/oauth/oauth.interface.d.ts
@@ -1,6 +1,7 @@
 import { User } from "../users/interfaces/user.interface";
 import { SessionData } from "express-session";
 import { Request, Response } from "express";
+import { OAuthDBService } from "./oauthDb.service";
 export declare class OAuthCredential {
     readonly id?: number;
     readonly access_token: string;
@@ -8,15 +9,10 @@ export declare class OAuthCredential {
     readonly expires_at: Date;
     readonly scope: string;
 }
-export declare abstract class OAuthManager {
+export declare abstract class OAuthManager extends OAuthDBService {
     abstract getOAuthUrl(state: string, scope: string): string;
     abstract getCredentials(code: string): Promise<OAuthCredential>;
-    abstract saveCredential(userId: User["id"], credential: OAuthCredential): Promise<number>;
-    abstract loadCredentialsByUserId(userId: User["id"]): Promise<OAuthCredential[]>;
-    abstract loadCredentialsByScopes(scopes: string[]): Promise<OAuthCredential[]>;
-    abstract loadCredentialById(oauthCredentialId: OAuthCredential["id"]): Promise<OAuthCredential>;
     abstract refreshCredential(oauthCredential: OAuthCredential): Promise<OAuthCredential>;
-    abstract updateCredential(oauthCredential: OAuthCredential): Promise<void>;
     abstract revokeCredential(oauthCredential: OAuthCredential): Promise<void>;
 }
 export declare function OAuthController_getOAuthUrl(): MethodDecorator & ClassDecorator;


### PR DESCRIPTION
This PR improves the security about the `state` param of the OAuth flow. It also implements the OAuth interface and controller for the Discord provider.

There are now action / reaction usable yet, as not implemented at the moment.